### PR TITLE
Re-instate Bundler version in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ rvm:
   - 2.2.2
   - 2.3.0
   - rbx-2.8
+before_install: gem install bundler -v 1.11.2
 sudo: false


### PR DESCRIPTION
Travis builds for JRuby and Ruby 1.9 fail without this.
