### PR TITLE
Run debt ceiling at exit during test suite, define modest ceiling

### DIFF
--- a/.debt_ceiling.rb
+++ b/.debt_ceiling.rb
@@ -1,0 +1,5 @@
+DebtCeiling.configure do |c|
+  c.whitelist = %w(lib)
+  c.max_debt_per_module = 50
+  c.debt_ceiling = 100
+end

--- a/alder.gemspec
+++ b/alder.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "debt_ceiling", "~> 0.4"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'alder'
+require 'debt_ceiling'
+at_exit { DebtCeiling.audit unless ENV['GUARD'] }
+


### PR DESCRIPTION
Not sure why rebasing PR #1 didn't work, closed in favor of this one, edited so you can avoid running with GUARD=true env var, could reverse it to `if ENV['CI']` or something I suppose and set CI env var on travis, but this seems simpler.
